### PR TITLE
Update testing configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 ---
 version: 2.1
 jobs:
-  build:
+  test:
     docker:
-      - image: girder/girder_test:latest-py3
+      - image: girder/girder_test:latest
       - image: circleci/mongo:4.0-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
@@ -30,7 +30,7 @@ workflows:
   version: 2
   ci:
     jobs:
-      - build
+      - test
   nightly:
     triggers:
       - schedule:
@@ -40,4 +40,4 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - test

--- a/{{cookiecutter.package_name}}/.circleci/config.yml
+++ b/{{cookiecutter.package_name}}/.circleci/config.yml
@@ -1,0 +1,38 @@
+---
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: girder/girder_test:latest
+      - image: circleci/mongo:4.0-ram
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
+
+    steps:
+      - checkout
+      - run:
+          name: Run server tests
+          command: tox
+{%- if cookiecutter.include_web_client_plugin == 'yes' %}
+      - run:
+          name: Run web tests
+          command: |
+            npm install
+            npm run lint
+          working_directory: {{cookiecutter.package_slug}}/web_client
+{%- endif %}
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     lint,
-    py3
+    test
 
-[testenv]
+[testenv:test]
 deps =
     pytest
     pytest-girder

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -5,14 +5,12 @@ envlist =
 
 [testenv]
 deps =
-    coverage
     mock
     pytest
-    pytest-cov
     pytest-girder>=0.1.0a1
     pytest-xdist
 commands =
-    pytest --cov {envsitepackagesdir}/{{ cookiecutter.package_slug }} {posargs}
+    pytest {posargs}
 
 [testenv:lint]
 skipsdist = true
@@ -68,14 +66,5 @@ ignore =
     W503,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term"
+addopts = --verbose --strict --showlocals
 testpaths = tests
-
-[coverage:paths]
-source =
-    {{ cookiecutter.package_slug }}/
-    .tox/*/lib/python*/site-packages/{{ cookiecutter.package_slug }}/
-
-[coverage:run]
-branch = True
-parallel = True

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -3,6 +3,9 @@ envlist =
     lint,
     test
 
+[testenv]
+basepython = python3
+
 [testenv:test]
 deps =
     pytest

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -5,10 +5,8 @@ envlist =
 
 [testenv]
 deps =
-    mock
     pytest
-    pytest-girder>=0.1.0a1
-    pytest-xdist
+    pytest-girder
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
* Remove Coverage from default tests
  * Code coverage is difficult to interpret properly and adds extra complexity to test infrastructure.
* Remove unnecessary packages from pytest testing
* Rename the Tox environment for pytest to "test"
* Ensure the Python 3 interpreter is used for Tox
* Update the CircleCI config with upstream Girder changes
* Add a CircleCI configuration file to the created project