### PR TITLE
Remove universal wheel setting

### DIFF
--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Python 2 is no longer supported, so this setting is no longer correct. It is not required for packaging.