### PR TITLE
Remove eslint-plugin-underscore due to security concerns.

### DIFF
--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_slug}}/web_client/package.json
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_slug}}/web_client/package.json
@@ -26,7 +26,6 @@
         "eslint-plugin-node": "*",
         "eslint-plugin-promise": "*",
         "eslint-plugin-standard": "*",
-        "eslint-plugin-underscore": "*",
         "pug-lint": "^2",
         "stylint": "^2"
     },


### PR DESCRIPTION
This matches Girder PR #3386.  See further comments there.