### PR TITLE
Remove --verbose from pytest

### DIFF
--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -66,5 +66,5 @@ ignore =
     W503,
 
 [pytest]
-addopts = --verbose --strict --showlocals
+addopts = --strict --showlocals
 testpaths = tests


### PR DESCRIPTION
This is just a proposal since I've found that the verbose flag makes tracebacks excessively hard to follow.